### PR TITLE
Fix datasource init using DataSourceProperties

### DIFF
--- a/src/main/java/br/com/prodemge/DORA/configuration/DatabaseConfig.java
+++ b/src/main/java/br/com/prodemge/DORA/configuration/DatabaseConfig.java
@@ -3,7 +3,7 @@ package br.com.prodemge.DORA.configuration;
 import javax.sql.DataSource;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -13,8 +13,13 @@ public class DatabaseConfig {
 
     @Bean
     @ConfigurationProperties("spring.datasource")
-    public DataSource dataSource() {
-        return DataSourceBuilder.create().build();
+    public DataSourceProperties dataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean
+    public DataSource dataSource(DataSourceProperties properties) {
+        return properties.initializeDataSourceBuilder().build();
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- use DataSourceProperties bean for datasource config
- build datasource from properties

## Testing
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686c31d9c7f8832f86e31cfdfb17a907