### PR TITLE
Add CRUD controllers, services and repositories for models

### DIFF
--- a/src/main/java/br/com/prodemge/DORA/controller/FeedbackController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/FeedbackController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.Feedback;
+import br.com.prodemge.DORA.service.FeedbackService;
+
+@RestController
+@RequestMapping("/feedbacks")
+public class FeedbackController {
+
+    @Autowired
+    private FeedbackService service;
+
+    @GetMapping
+    public List<Feedback> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Feedback> getById(@PathVariable Long id) {
+        Feedback entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<Feedback> create(@RequestBody Feedback entity) {
+        Feedback created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Feedback> update(@PathVariable Long id, @RequestBody Feedback entity) {
+        Feedback updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/NotificationController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/NotificationController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.Notification;
+import br.com.prodemge.DORA.service.NotificationService;
+
+@RestController
+@RequestMapping("/notifications")
+public class NotificationController {
+
+    @Autowired
+    private NotificationService service;
+
+    @GetMapping
+    public List<Notification> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Notification> getById(@PathVariable Long id) {
+        Notification entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<Notification> create(@RequestBody Notification entity) {
+        Notification created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Notification> update(@PathVariable Long id, @RequestBody Notification entity) {
+        Notification updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/OpinionController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/OpinionController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.Opinion;
+import br.com.prodemge.DORA.service.OpinionService;
+
+@RestController
+@RequestMapping("/opinions")
+public class OpinionController {
+
+    @Autowired
+    private OpinionService service;
+
+    @GetMapping
+    public List<Opinion> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Opinion> getById(@PathVariable Long id) {
+        Opinion entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<Opinion> create(@RequestBody Opinion entity) {
+        Opinion created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Opinion> update(@PathVariable Long id, @RequestBody Opinion entity) {
+        Opinion updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/OpinionRevisionController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/OpinionRevisionController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.OpinionRevision;
+import br.com.prodemge.DORA.service.OpinionRevisionService;
+
+@RestController
+@RequestMapping("/opinion-revisions")
+public class OpinionRevisionController {
+
+    @Autowired
+    private OpinionRevisionService service;
+
+    @GetMapping
+    public List<OpinionRevision> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OpinionRevision> getById(@PathVariable Long id) {
+        OpinionRevision entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<OpinionRevision> create(@RequestBody OpinionRevision entity) {
+        OpinionRevision created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<OpinionRevision> update(@PathVariable Long id, @RequestBody OpinionRevision entity) {
+        OpinionRevision updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/ProcessController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/ProcessController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.Process;
+import br.com.prodemge.DORA.service.ProcessService;
+
+@RestController
+@RequestMapping("/processes")
+public class ProcessController {
+
+    @Autowired
+    private ProcessService service;
+
+    @GetMapping
+    public List<Process> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Process> getById(@PathVariable Long id) {
+        Process entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<Process> create(@RequestBody Process entity) {
+        Process created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Process> update(@PathVariable Long id, @RequestBody Process entity) {
+        Process updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/ProcessStatusController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/ProcessStatusController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.ProcessStatus;
+import br.com.prodemge.DORA.service.ProcessStatusService;
+
+@RestController
+@RequestMapping("/process-statuses")
+public class ProcessStatusController {
+
+    @Autowired
+    private ProcessStatusService service;
+
+    @GetMapping
+    public List<ProcessStatus> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProcessStatus> getById(@PathVariable Long id) {
+        ProcessStatus entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<ProcessStatus> create(@RequestBody ProcessStatus entity) {
+        ProcessStatus created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProcessStatus> update(@PathVariable Long id, @RequestBody ProcessStatus entity) {
+        ProcessStatus updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/ProcessTypeController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/ProcessTypeController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.ProcessType;
+import br.com.prodemge.DORA.service.ProcessTypeService;
+
+@RestController
+@RequestMapping("/process-types")
+public class ProcessTypeController {
+
+    @Autowired
+    private ProcessTypeService service;
+
+    @GetMapping
+    public List<ProcessType> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProcessType> getById(@PathVariable Long id) {
+        ProcessType entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<ProcessType> create(@RequestBody ProcessType entity) {
+        ProcessType created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProcessType> update(@PathVariable Long id, @RequestBody ProcessType entity) {
+        ProcessType updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/RoleController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/RoleController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.Role;
+import br.com.prodemge.DORA.service.RoleService;
+
+@RestController
+@RequestMapping("/roles")
+public class RoleController {
+
+    @Autowired
+    private RoleService service;
+
+    @GetMapping
+    public List<Role> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Role> getById(@PathVariable Long id) {
+        Role entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<Role> create(@RequestBody Role entity) {
+        Role created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Role> update(@PathVariable Long id, @RequestBody Role entity) {
+        Role updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/TermAcceptanceController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/TermAcceptanceController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.TermAcceptance;
+import br.com.prodemge.DORA.service.TermAcceptanceService;
+
+@RestController
+@RequestMapping("/terms-acceptance")
+public class TermAcceptanceController {
+
+    @Autowired
+    private TermAcceptanceService service;
+
+    @GetMapping
+    public List<TermAcceptance> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TermAcceptance> getById(@PathVariable Long id) {
+        TermAcceptance entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<TermAcceptance> create(@RequestBody TermAcceptance entity) {
+        TermAcceptance created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TermAcceptance> update(@PathVariable Long id, @RequestBody TermAcceptance entity) {
+        TermAcceptance updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/UserController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/UserController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.User;
+import br.com.prodemge.DORA.service.UserService;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    private UserService service;
+
+    @GetMapping
+    public List<User> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getById(@PathVariable Long id) {
+        User entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<User> create(@RequestBody User entity) {
+        User created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<User> update(@PathVariable Long id, @RequestBody User entity) {
+        User updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/controller/UserRoleController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/UserRoleController.java
@@ -1,0 +1,61 @@
+package br.com.prodemge.DORA.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.UserRole;
+import br.com.prodemge.DORA.service.UserRoleService;
+
+@RestController
+@RequestMapping("/user-roles")
+public class UserRoleController {
+
+    @Autowired
+    private UserRoleService service;
+
+    @GetMapping
+    public List<UserRole> listAll() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<UserRole> getById(@PathVariable Long id) {
+        UserRole entity = service.findById(id);
+        if (entity == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(entity);
+    }
+
+    @PostMapping
+    public ResponseEntity<UserRole> create(@RequestBody UserRole entity) {
+        UserRole created = service.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<UserRole> update(@PathVariable Long id, @RequestBody UserRole entity) {
+        UserRole updated = service.update(id, entity);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/FeedbackRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/FeedbackRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.Feedback;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/NotificationRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/OpinionRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/OpinionRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.Opinion;
+
+@Repository
+public interface OpinionRepository extends JpaRepository<Opinion, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/OpinionRevisionRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/OpinionRevisionRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.OpinionRevision;
+
+@Repository
+public interface OpinionRevisionRepository extends JpaRepository<OpinionRevision, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/ProcessRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/ProcessRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.Process;
+
+@Repository
+public interface ProcessRepository extends JpaRepository<Process, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/ProcessStatusRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/ProcessStatusRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.ProcessStatus;
+
+@Repository
+public interface ProcessStatusRepository extends JpaRepository<ProcessStatus, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/ProcessTypeRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/ProcessTypeRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.ProcessType;
+
+@Repository
+public interface ProcessTypeRepository extends JpaRepository<ProcessType, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/RoleRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.Role;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/TermAcceptanceRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/TermAcceptanceRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.TermAcceptance;
+
+@Repository
+public interface TermAcceptanceRepository extends JpaRepository<TermAcceptance, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/UserRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/UserRoleRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/UserRoleRepository.java
@@ -1,0 +1,10 @@
+package br.com.prodemge.DORA.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.com.prodemge.DORA.model.UserRole;
+
+@Repository
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+}

--- a/src/main/java/br/com/prodemge/DORA/service/FeedbackService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/FeedbackService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FeedbackService {
+    @Autowired
+    private FeedbackRepository repository;
+
+    public List<Feedback> findAll() {
+        return repository.findAll();
+    }
+
+    public Feedback findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public Feedback create(Feedback entity) {
+        return repository.save(entity);
+    }
+
+    public Feedback update(Long id, Feedback entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/NotificationService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/NotificationService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+    @Autowired
+    private NotificationRepository repository;
+
+    public List<Notification> findAll() {
+        return repository.findAll();
+    }
+
+    public Notification findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public Notification create(Notification entity) {
+        return repository.save(entity);
+    }
+
+    public Notification update(Long id, Notification entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/OpinionRevisionService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/OpinionRevisionService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpinionRevisionService {
+    @Autowired
+    private OpinionRevisionRepository repository;
+
+    public List<OpinionRevision> findAll() {
+        return repository.findAll();
+    }
+
+    public OpinionRevision findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public OpinionRevision create(OpinionRevision entity) {
+        return repository.save(entity);
+    }
+
+    public OpinionRevision update(Long id, OpinionRevision entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/OpinionService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/OpinionService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OpinionService {
+    @Autowired
+    private OpinionRepository repository;
+
+    public List<Opinion> findAll() {
+        return repository.findAll();
+    }
+
+    public Opinion findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public Opinion create(Opinion entity) {
+        return repository.save(entity);
+    }
+
+    public Opinion update(Long id, Opinion entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/ProcessService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/ProcessService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProcessService {
+    @Autowired
+    private ProcessRepository repository;
+
+    public List<Process> findAll() {
+        return repository.findAll();
+    }
+
+    public Process findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public Process create(Process entity) {
+        return repository.save(entity);
+    }
+
+    public Process update(Long id, Process entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/ProcessStatusService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/ProcessStatusService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProcessStatusService {
+    @Autowired
+    private ProcessStatusRepository repository;
+
+    public List<ProcessStatus> findAll() {
+        return repository.findAll();
+    }
+
+    public ProcessStatus findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public ProcessStatus create(ProcessStatus entity) {
+        return repository.save(entity);
+    }
+
+    public ProcessStatus update(Long id, ProcessStatus entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/ProcessTypeService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/ProcessTypeService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProcessTypeService {
+    @Autowired
+    private ProcessTypeRepository repository;
+
+    public List<ProcessType> findAll() {
+        return repository.findAll();
+    }
+
+    public ProcessType findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public ProcessType create(ProcessType entity) {
+        return repository.save(entity);
+    }
+
+    public ProcessType update(Long id, ProcessType entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/RoleService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/RoleService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleService {
+    @Autowired
+    private RoleRepository repository;
+
+    public List<Role> findAll() {
+        return repository.findAll();
+    }
+
+    public Role findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public Role create(Role entity) {
+        return repository.save(entity);
+    }
+
+    public Role update(Long id, Role entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/TermAcceptanceService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/TermAcceptanceService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TermAcceptanceService {
+    @Autowired
+    private TermAcceptanceRepository repository;
+
+    public List<TermAcceptance> findAll() {
+        return repository.findAll();
+    }
+
+    public TermAcceptance findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public TermAcceptance create(TermAcceptance entity) {
+        return repository.save(entity);
+    }
+
+    public TermAcceptance update(Long id, TermAcceptance entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/UserRoleService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/UserRoleService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserRoleService {
+    @Autowired
+    private UserRoleRepository repository;
+
+    public List<UserRole> findAll() {
+        return repository.findAll();
+    }
+
+    public UserRole findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public UserRole create(UserRole entity) {
+        return repository.save(entity);
+    }
+
+    public UserRole update(Long id, UserRole entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/service/UserService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/UserService.java
@@ -1,0 +1,38 @@
+package br.com.prodemge.DORA.service;
+
+import java.util.List;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    @Autowired
+    private UserRepository repository;
+
+    public List<User> findAll() {
+        return repository.findAll();
+    }
+
+    public User findById(Long id) {
+        return repository.findById(id).orElse(null);
+    }
+
+    public User create(User entity) {
+        return repository.save(entity);
+    }
+
+    public User update(Long id, User entity) {
+        return repository.findById(id)
+                .map(existing -> {
+                    BeanUtils.copyProperties(entity, existing, "id");
+                    return repository.save(existing);
+                })
+                .orElse(null);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement CRUD layers for all model classes
- add Spring services with BeanUtils-based update methods
- provide REST controllers for each entity
- create JpaRepository interfaces for database access

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4641d658832f91a439cc11d04aef