### PR TITLE
Implement email/password authentication

### DIFF
--- a/src/main/java/br/com/prodemge/DORA/controller/AuthenticationController.java
+++ b/src/main/java/br/com/prodemge/DORA/controller/AuthenticationController.java
@@ -1,0 +1,23 @@
+package br.com.prodemge.DORA.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.prodemge.DORA.model.AuthRequest;
+import br.com.prodemge.DORA.service.UserService;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthenticationController {
+
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/login")
+    public boolean authenticate(@RequestBody AuthRequest request) {
+        return userService.authenticate(request.getEmail(), request.getPassword());
+    }
+}

--- a/src/main/java/br/com/prodemge/DORA/model/AuthRequest.java
+++ b/src/main/java/br/com/prodemge/DORA/model/AuthRequest.java
@@ -1,0 +1,15 @@
+package br.com.prodemge.DORA.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/br/com/prodemge/DORA/repository/UserRepository.java
+++ b/src/main/java/br/com/prodemge/DORA/repository/UserRepository.java
@@ -3,8 +3,11 @@ package br.com.prodemge.DORA.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 import br.com.prodemge.DORA.model.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmailAndPassword(String email, String password);
 }

--- a/src/main/java/br/com/prodemge/DORA/service/UserService.java
+++ b/src/main/java/br/com/prodemge/DORA/service/UserService.java
@@ -1,10 +1,14 @@
 package br.com.prodemge.DORA.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import br.com.prodemge.DORA.model.User;
+import br.com.prodemge.DORA.repository.UserRepository;
 
 @Service
 public class UserService {
@@ -34,5 +38,9 @@ public class UserService {
 
     public void delete(Long id) {
         repository.deleteById(id);
+    }
+
+    public boolean authenticate(String email, String password) {
+        return repository.findByEmailAndPassword(email, password).isPresent();
     }
 }


### PR DESCRIPTION
## Summary
- add `AuthRequest` DTO
- add `AuthenticationController` endpoint for `/auth/login`
- enable repository method to locate users by email and password
- provide service method for authentication logic

## Testing
- `./mvnw -q test` *(fails: could not download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_686c5424501c832f9959bd8575130b83